### PR TITLE
Chore/refactor GitHub Action & Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           context: .
           # platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/test-') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ ingest-restart:
 	$(COMPOSE) up -d --no-deps --remove-orphans --force-recreate ingest-file
 
 dev:
-	python3 -m pip install --upgrade pip setuptools poetry
-	python3 -m poetry install --with dev
+	python3 -m pip install --upgrade pip
+	python3 -m pip install -q -r requirements.txt
+	python3 -m pip install -q -r requirements-dev.txt
 
 fixtures:
 	aleph crawldir --wait -f fixtures aleph/tests/fixtures/samples
@@ -121,4 +122,3 @@ e2e-local:
 	pytest -s -v --screenshot only-on-failure e2e/
 
 .PHONY: build services e2e
-


### PR DESCRIPTION
The GitHub Action that builds an Aleph image and pushes it to GHCR (GitHub Container Registry) was refactored to only push an image is a commit was tagged. This follows [the principle](https://github.com/alephdata/aleph/blob/develop/.github/workflows/build.yml#L58C13-L58C125) that the OCCRP Aleph repo uses. This prevents numerous images being pushed to GHCR on every single push - some of these are not useful images.

The Makefile refactor is needed in order to be able to run things like `make format-check` and `make lint`. 

By default, `poetry install` will create a virtualenv. This means that, after running `make dev` in the [linting GitHub Action](https://github.com/investigativedata/aleph/blob/main/.github/workflows/pr.yml), `black` and `ruff` have been installed in a Poetry venv, and will appear as missing from the system (so the subsequent command will fail). 

I have restored using pip only to manage the dependencies, in order to be able to use this GitHub Action.

Going forward, this repo should settle on either using Poetry or pip in the Makefile. 

